### PR TITLE
qt5-base: Change OpenGL to use "dynamic" mode to support fallback

### DIFF
--- a/mingw-w64-qt5-base/PKGBUILD
+++ b/mingw-w64-qt5-base/PKGBUILD
@@ -227,7 +227,7 @@ build() {
     -shared \
     -make-tool make \
     -I${MINGW_PREFIX}/include/mariadb \
-    -opengl desktop \
+    -opengl dynamic \
     -dbus \
     -fontconfig \
     -icu \


### PR DESCRIPTION
Changing to -opengl dynamic will enable fallback code for loading ANGLE (libEGL.dll and libGLESv2.dll from package mingw-*-angleproject) as well as software rasterizers (openg32sw.dll) at runtime. Currently -opengl desktop will only work with full-fledged OpenGL 2.x+ implementation, that is: Qt Quick 2 will not work in VMs without 3D acceleration.